### PR TITLE
Mention canonicaljson-rs implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ JSON text in canonical form:
 
 The following projects are known to correctly implement this specification:
 * [canonicaljson-go](https://godoc.org/github.com/gibson042/canonicaljson-go)
+* [canonicaljson-rs](https://github.com/mozilla-services/canonicaljson-rs) (*serializer only*)
 
 If you know of any others, please submit a pull request to add them!
 


### PR DESCRIPTION
While I was working on the [necessary adjustments to our canonicaljson-rs serialization crate](https://github.com/mozilla-services/canonicaljson-rs/pull/4), I realized that there is a chance we never get the shell tests suite pass, mostly because we rely on the common JSON deserializer and that crunches some parts of the test suite.

Do you think it is still worth mentioning it here in your repo? If you would only consider implementations that pass 100% I would also completely understand.

Thanks for your feedback!